### PR TITLE
Update for SDK v2.4.4

### DIFF
--- a/FuturaeDemo/app/build.gradle
+++ b/FuturaeDemo/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "com.futurae.futuraedemo"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 12
         versionName "2.3.0"
     }
@@ -79,9 +79,9 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.15.0'
 
     // Futurae SDK
-    implementation 'com.futurae.sdk:futuraekit:2.4.3'
+    implementation 'com.futurae.sdk:futuraekit:2.4.4'
     // OPTIONAL - Adaptive SDK.
-    implementation 'com.futurae.sdk:adaptive:1.0.0-alpha'
+    implementation 'com.futurae.sdk:adaptive:1.0.2-alpha'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/FuturaeDemo/app/src/main/AndroidManifest.xml
+++ b/FuturaeDemo/app/src/main/AndroidManifest.xml
@@ -99,6 +99,11 @@
             android:exported="false"
             android:screenOrientation="portrait" />
 
+        <activity
+            android:name=".ui.activity.ActivitySDKConfiguration"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+
     </application>
 
 </manifest>

--- a/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/FuturaeSdkWrapper.kt
+++ b/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/FuturaeSdkWrapper.kt
@@ -9,5 +9,5 @@ object FuturaeSdkWrapper {
         get() = FuturaeSDK.INSTANCE
 
     val client: FuturaeClient
-        get() = sdk.client
+        get() = sdk.getClient()
 }

--- a/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/activity/AdaptiveCollectionsOverviewActivity.kt
+++ b/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/activity/AdaptiveCollectionsOverviewActivity.kt
@@ -45,12 +45,12 @@ class AdaptiveViewerActivity : FuturaeActivity() {
         binding.recycler.adapter = adapter
         binding.clearCollections.setOnClickListener {
             lifecycleScope.launch(Dispatchers.IO) {
-                AdaptiveDbHelper.INSTANCE.deleteAllCollections()
+                AdaptiveDbHelper.deleteAllCollections()
             }
         }
 
         lifecycleScope.launch(Dispatchers.Main) {
-            AdaptiveDbHelper.INSTANCE.allCollections.collect {
+            AdaptiveDbHelper.getAllCollections().collect {
                 binding.emptyText.isVisible = it.isEmpty()
                 binding.recycler.isVisible = it.isNotEmpty()
                 binding.clearCollections.isVisible = it.isNotEmpty()

--- a/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/activity/MainActivity.kt
+++ b/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/activity/MainActivity.kt
@@ -111,16 +111,9 @@ class MainActivity : FuturaeActivity(), FragmentConfiguration.Listener, Fragment
                         }
                     )
                 }
+                else -> showErrorAlert("SDK initialization failed", e)
             }
         }
-    }
-
-    private fun onSDKLaunched(sdkConfiguration: SDKConfiguration) {
-        localStorage.persistSDKConfiguration(sdkConfiguration)
-        supportFragmentManager
-            .beginTransaction()
-            .replace(R.id.fragmentContainer, FragmentMain())
-            .commit()
     }
 
     override fun onSDKReset() {
@@ -134,6 +127,17 @@ class MainActivity : FuturaeActivity(), FragmentConfiguration.Listener, Fragment
             .beginTransaction()
             .replace(R.id.fragmentContainer, FragmentMain())
             .commit()
+    }
+
+    private fun onSDKLaunched(sdkConfiguration: SDKConfiguration) {
+        localStorage.persistSDKConfiguration(sdkConfiguration)
+        supportFragmentManager
+            .beginTransaction()
+            .replace(R.id.fragmentContainer, FragmentMain())
+            .commit()
+        pendingUri?.let {
+            handleUri(it)
+        }
     }
 
     private fun checkPermissions() {

--- a/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/fragment/FragmentConfiguration.kt
+++ b/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/fragment/FragmentConfiguration.kt
@@ -66,10 +66,10 @@ class FragmentConfiguration : Fragment() {
             }
         }
         binding.corruptv1KeysButton.setOnClickListener {
-            FuturaeDebugUtil.INSTANCE.corruptV1Keys(requireContext())
+            FuturaeDebugUtil.corruptV1Keys(requireContext())
         }
         binding.corruptDbButton.setOnClickListener {
-            FuturaeDebugUtil.INSTANCE.corruptDBTokens(requireContext())
+            FuturaeDebugUtil.corruptDBTokens(requireContext())
         }
     }
 

--- a/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/fragment/FragmentSDKOperations.kt
+++ b/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/fragment/FragmentSDKOperations.kt
@@ -73,7 +73,7 @@ abstract class FragmentSDKOperations : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         toggleAdaptiveButton().setOnClickListener {
-            if (FuturaeSdkWrapper.sdk.isAdaptiveEnabled) {
+            if (FuturaeSdkWrapper.sdk.isAdaptiveEnabled()) {
                 FuturaeSdkWrapper.sdk.disableAdaptive()
                 toggleAdaptiveButton().text = "Enable Adaptive"
             } else {
@@ -82,7 +82,7 @@ abstract class FragmentSDKOperations : Fragment() {
             }
         }
         viewAdaptiveCollectionsButton().setOnClickListener {
-            if (FuturaeSdkWrapper.sdk.isAdaptiveEnabled) {
+            if (FuturaeSdkWrapper.sdk.isAdaptiveEnabled()) {
                 startActivity(
                     Intent(context, AdaptiveViewerActivity::class.java)
                 )
@@ -91,11 +91,11 @@ abstract class FragmentSDKOperations : Fragment() {
             }
         }
         toggleAdaptiveButton().text =
-            if (FuturaeSdkWrapper.sdk.isAdaptiveEnabled) "Disable Adaptive" else "Enable Adaptive"
+            if (FuturaeSdkWrapper.sdk.isAdaptiveEnabled()) "Disable Adaptive" else "Enable Adaptive"
 
         setAdaptiveThreshold().setOnClickListener {
             if (FuturaeSdkWrapper.sdk.isAdaptiveEnabled()) {
-                var sliderValue = AdaptiveSDK.INSTANCE.adaptiveCollectionThreshold
+                var sliderValue = AdaptiveSDK.getAdaptiveCollectionThreshold()
                 val dialogView = layoutInflater.inflate(R.layout.dialog_adaptive_time, null)
                 val textValue = dialogView.findViewById<TextView>(R.id.sliderValue).apply {
                     text = "$sliderValue sec"
@@ -109,7 +109,7 @@ abstract class FragmentSDKOperations : Fragment() {
                 }
                 val dialog = AlertDialog.Builder(requireContext(), R.style.Theme_Material3_Light_Dialog)
                     .setTitle("Adaptive time threshold").setView(dialogView).setPositiveButton("OK") { dialog, which ->
-                        AdaptiveSDK.INSTANCE.adaptiveCollectionThreshold = sliderValue
+                        AdaptiveSDK.setAdaptiveCollectionThreshold(sliderValue)
                     }.create()
                 dialog.show()
             } else {
@@ -465,7 +465,7 @@ abstract class FragmentSDKOperations : Fragment() {
                         "Would you like to approve the request?${session.toDialogMessage()}",
                         "Approve",
                         {
-                            FuturaeSdkWrapper.sdk.client.approveAuthWithUsernamelessQrCode(
+                            FuturaeSdkWrapper.sdk.getClient().approveAuthWithUsernamelessQrCode(
                                 qrCode,
                                 userId,
                                 session.info,
@@ -483,7 +483,7 @@ abstract class FragmentSDKOperations : Fragment() {
                         },
                         "Deny",
                         {
-                            FuturaeSdkWrapper.sdk.client.rejectAuthWithUsernamelessQrCode(
+                            FuturaeSdkWrapper.sdk.getClient().rejectAuthWithUsernamelessQrCode(
                                 qrCode,
                                 userId,
                                 false,

--- a/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/fragment/FragmentSettings.kt
+++ b/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/fragment/FragmentSettings.kt
@@ -87,12 +87,12 @@ class FragmentSettings : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.buttonLoggout.setOnClickListener {
-            val accounts = FuturaeSdkWrapper.sdk.client.accounts
+            val accounts = FuturaeSdkWrapper.sdk.getClient().accounts
             if (accounts.isEmpty()) {
                 showErrorAlert("SDK Error", Throwable("No accounts found to logout"))
             } else {
                 accounts.forEach { account ->
-                    FuturaeSdkWrapper.sdk.client.logout(account.userId, object : FuturaeCallback {
+                    FuturaeSdkWrapper.sdk.getClient().logout(account.userId, object : FuturaeCallback {
                         override fun success() {
                             Toast.makeText(requireContext(), "Logout successful", Toast.LENGTH_SHORT).show()
                         }
@@ -131,7 +131,13 @@ class FragmentSettings : Fragment() {
             })
         }
         binding.buttonClearEncrypted.setOnClickListener {
-            FuturaeDebugUtil.INSTANCE.clearEncryptedTokens()
+            FuturaeDebugUtil.clearEncryptedTokens()
+        }
+        binding.buttonClearV2Keys.setOnClickListener {
+            FuturaeDebugUtil.corruptV2Keys(requireContext())
+        }
+        binding.buttonClearV2LocalStorageKey.setOnClickListener {
+            FuturaeDebugUtil.corruptEncryptedStorageKey(requireContext())
         }
     }
 

--- a/FuturaeDemo/app/src/main/res/layout/fragment_sdk_settings.xml
+++ b/FuturaeDemo/app/src/main/res/layout/fragment_sdk_settings.xml
@@ -63,6 +63,20 @@
             android:layout_marginTop="10dp"
             android:text="Clear encrypted storage" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonClearV2Keys"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="Clear V2 keys" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonClearV2LocalStorageKey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="Clear V2 storage key" />
+
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/FuturaeDemo/app/src/main/res/values/strings.xml
+++ b/FuturaeDemo/app/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
 	<string name="app_name">FuturaeDemo</string>
 
 	<string name="qrcode_title">QR Code</string>
-	<string name="permission_rationale">This app requires permission for camera to Scan QR codes and to show Notifications</string>
 	<string name="error_low_storage">QR code scanning cannot be performed due to low device storage</string>
 
 	<string name="menu_home">Home</string>


### PR DESCRIPTION
### Changelog
- Fix `FuturaeSDK.reset` throwing keystore related errors.
- Add debug utility that deletes local encrypted storage key to simulate a specific type of keystore failure that will make certain operations return `LockUnexpectedException` or `FTKeystoreException`.
- Introduced new Exception from SDK callback operations `FTMissingTokensException`  which is a recoverable exception via SDK account recovery.
- SDK synchronous cryptographic-related operations now declare the Exceptions they may throw on their signature to enforce handling them.
- Removed SDK logs entirely.
- Prevent SDK account recovery race condition with `getAccountsStatus`.
- Bump `compile/target` SDK version to 34 and gradle plugin version to `7.4.2`